### PR TITLE
Race Overhaul Port

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -62,6 +62,24 @@
 		icon_state = "stickyweb2"
 	return ..()
 
+
+/obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /mob/living/simple_mob/animal/giant_spider))
+		return TRUE
+	else if(istype(mover, /mob/living))
+		var/mob/living/carbon/human/human_mover = mover
+		if(istype(human_mover.species, /datum/species/spider))//spider people dont get stuck in webs
+			return TRUE
+		else if(istype(mover, /mob/living))
+			if(prob(50))
+				to_chat(mover, span("warning", "You get stuck in \the [src] for a moment."))
+				return FALSE
+	else if(istype(mover, /obj/item/projectile))
+		return prob(30)
+	return TRUE
+
+
+/*
 /obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover, /mob/living/simple_mob/animal/giant_spider))
 		return TRUE
@@ -72,6 +90,7 @@
 	else if(istype(mover, /obj/item/projectile))
 		return prob(30)
 	return TRUE
+*/
 
 /obj/effect/spider/eggcluster
 	name = "egg cluster"

--- a/code/modules/mob/living/carbon/human/species/station/seromi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/seromi.dm
@@ -44,14 +44,15 @@
 
 	slowdown = -1
 	snow_movement = -2	// Ignores light snow
-	item_slowdown_mod = 2	// Tiny birds don't like heavy things
-	total_health = 50
+//	item_slowdown_mod = 2	// Tiny birds don't like heavy things --removed in raceport
+//	total_health = 50
+	total_health = 75	// Increased from 50 to make them less super killable --raceport
 	brute_mod = 1.35
 	burn_mod =  1.35
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
 	holder_type = /obj/item/weapon/holder/human
-//	short_sighted = 1
+	short_sighted =	1	//Added back in, makes players use sonar ping --raceport
 	gluttonous = 1
 	blood_volume = 400
 	hunger_factor = 0.2

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -51,7 +51,7 @@
 	item_slowdown_mod = 0.25
 	mob_size = MOB_LARGE
 	blood_volume = 840
-	bloodloss_rate = 0.75
+	//bloodloss_rate = 0.75	//Unathi Rebalance Attempt #1 --raceport
 	num_alternate_languages = 3
 	secondary_langs = list(LANGUAGE_UNATHI)
 	name_language = LANGUAGE_UNATHI

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -335,6 +335,7 @@
 	icobase_tail = 1
 
 	inherent_verbs = list(
+		/mob/proc/weaveWeb, //raceport
 		/mob/proc/weaveWebBindings)
 
 	min_age = 18

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -11,6 +11,14 @@
 	//brute_mod = 1.15
 	//burn_mod =  1.15
 	//gluttonous = 1
+
+	//raceport sergal changes 1
+	darksight = 5
+	slowdown = -0.3		//Fast, but not as fast as Taj
+	burn_mod =  1.15	//Fur is flammable
+	metabolic_rate = 1.2
+	//raceport sergal changes 1 end
+
 	num_alternate_languages = 3
 	secondary_langs = list(LANGUAGE_SAGARU)
 	name_language = LANGUAGE_SAGARU
@@ -31,6 +39,30 @@
 	wikilink="https://wiki.vore-station.net/Backstory#Sergal"
 
 	catalogue_data = list(/datum/category_item/catalogue/fauna/sergal)
+
+	//raceport sergal changes 2
+
+	body_temperature = 315	//Cold resistant and flammable due to higher body temp, but not as high as Taj.
+
+	cold_level_1 = 230 //Default 260	//Not as resistant as Taj
+	cold_level_2 = 170 //Default 200
+	cold_level_3 = 90  //Default 120
+
+	heat_level_1 = 340 //Default 360	//Not as prone to overheat as Taj
+	heat_level_2 = 390 //Default 400
+	heat_level_3 = 850 //Default 1000
+
+
+	breath_cold_level_1 = 180	//Default 240 - Lower is better
+	breath_cold_level_2 = 100	//Default 180
+	breath_cold_level_3 = 60	//Default 100
+
+
+	breath_heat_level_1 = 360	//Default 380 - Higher is better
+	breath_heat_level_2 = 430	//Default 450
+	breath_heat_level_3 = 1000	//Default 1250
+
+	//raceport sergal changes 2 end
 
 	primitive_form = "Saru"
 
@@ -68,18 +100,26 @@
 	deform = 'icons/mob/human_races/r_def_akula.dmi'
 	tail = "tail"
 	icobase_tail = 1
-	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/strong)//raceport-sharp bite changed to strong
 	//darksight = 8
 	//slowdown = -0.5
 	//brute_mod = 1.15
 	//burn_mod =  1.15
 	//gluttonous = 1
+
+	//raceport akula changes 1
+	darksight = 7	//Sharks have good darkvision
+	water_movement = -5			//Sharks swim really fast
+	siemens_coefficient = 1.5	//Sharks are more sensitive to electrical signals, and they're aquatic. Seems a reasonable tradeoff.
+	//raceport akula changes 1 end
+
 	num_alternate_languages = 3
 	secondary_langs = list(LANGUAGE_SKRELLIAN)
 	name_language = LANGUAGE_SKRELLIAN
 	color_mult = 1
 	inherent_verbs = list(/mob/living/proc/shred_limb)
-	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
+//	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
+	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_TERMINUS, LANGUAGE_SKRELLIANFAR, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)	//KTT edit: Removes Skrellian from assisted languages as a patch -- Raceport
 
 	min_age = 18
 	max_age = 80
@@ -166,6 +206,7 @@
 	secondary_langs = list(LANGUAGE_TERMINUS)
 	name_language = LANGUAGE_TERMINUS
 	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds)
+	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_SKRELLIAN, LANGUAGE_SKRELLIANFAR, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)	//KTT edit: Zorren can speak Terminus unassisted. --Racepatch
 
 	min_age = 18
 	max_age = 80
@@ -209,6 +250,7 @@
 	num_alternate_languages = 3
 	secondary_langs = list(LANGUAGE_TERMINUS)
 	name_language = LANGUAGE_TERMINUS
+	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_SKRELLIAN, LANGUAGE_SKRELLIANFAR, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)	//KTT edit: Zorren can speak Terminus unassisted. --Racepatch
 	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds)
 
 	min_age = 18
@@ -279,6 +321,26 @@
 
 	flesh_color = "#966464"
 	base_color = "#B43214"
+
+//Raceport vulpkanin changes
+
+	cold_level_1 = 240 //Default 260 - Lower is better
+	cold_level_2 = 180 //Default 200
+	cold_level_3 = 100 //Default 120
+
+	breath_cold_level_1 = 220	//Default 240 - Lower is better
+	breath_cold_level_2 = 150	//Default 180
+	breath_cold_level_3 = 70	//Default 100
+
+	heat_level_1 = 380 //Default 360 - Higher is better
+	heat_level_2 = 420 //Default 400
+	heat_level_3 = 1050 //Default 1000
+
+	breath_heat_level_1 = 400	//Default 380 - Higher is better
+	breath_heat_level_2 = 480	//Default 450
+	breath_heat_level_3 = 1300	//Default 1250
+
+//raceport vulpkanin changes end
 
 	min_age = 18
 	max_age = 80

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -34,10 +34,14 @@
 				data -= taste
 
 /datum/reagent/nutriment/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	/* VOREStation Removal
 	if(!injectable && alien != IS_SLIME && alien != IS_CHIMERA) //VOREStation Edit
 		M.adjustToxLoss(0.1 * removed)
 		return
 	affect_ingest(M, alien, removed)
+	*/ //VOREStation Removal End
+	if(injectable) //vorestation addition/replacement
+		affect_ingest(M, alien, removed)//raceport- removes promethians being poisoned by nutriment?
 
 /datum/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	switch(alien)
@@ -1963,23 +1967,23 @@
 	M.sleeping = max(0, M.sleeping - 2)
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
-	//if(alien == IS_TAJARA)
-		//M.adjustToxLoss(0.5 * removed)
-		//M.make_jittery(4) //extra sensitive to caffine
+	if(alien == IS_TAJARA)//raceport- tajaran coffee sensitivity
+		M.adjustToxLoss(0.5 * removed)
+		M.make_jittery(4) //extra sensitive to caffine
 
 /datum/reagent/ethanol/coffee/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	//if(alien == IS_TAJARA)
-		//M.adjustToxLoss(2 * removed)
-		//M.make_jittery(4)
-		//return
+	if(alien == IS_TAJARA)//raceport- tajaran coffee sensitivity
+		M.adjustToxLoss(2 * removed)
+		M.make_jittery(4)
+		return
 	..()
 
 /datum/reagent/ethanol/coffee/overdose(var/mob/living/carbon/M, var/alien)
 	if(alien == IS_DIONA)
 		return
-	//if(alien == IS_TAJARA)
-		//M.adjustToxLoss(4 * REM)
-		//M.apply_effect(3, STUTTER) //VOREStation Edit end
+	if(alien == IS_TAJARA)//raceport- tajaran coffee sensitivity
+		M.adjustToxLoss(4 * REM)
+		M.apply_effect(3, STUTTER) //VOREStation Edit end
 	M.make_jittery(5)
 
 /datum/reagent/ethanol/coffee/kahlua

--- a/code/modules/vore/appearance/spider_taur_powers_vr.dm
+++ b/code/modules/vore/appearance/spider_taur_powers_vr.dm
@@ -19,18 +19,16 @@ obj/item/clothing/suit/web_bindings
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 
-/* //Commenting all this out, as people keep abusing it. Sorry!
 mob/proc/weaveWeb()
 	set name = "Weave Web"
 	set category = "Species Powers"
-	if(nutrition >= 500) //People decided to abuse it. Sorry. It was asked to be made so it couldn't be spammed, and what do ya know, people are spamming it everywhere.
+	if(nutrition >= 500)
 		src.visible_message("<span class='notice'>\the [src] weaves a web from their spinneret silk.</span>")
 		nutrition -= 500
 		spawn(30) //3 seconds to form
 		new /obj/effect/spider/stickyweb(src.loc)
 	else
 		src << "You do not have enough nutrition to create webbing!"
-*/
 
 mob/proc/weaveWebBindings()
 	set name = "Weave Web Bindings"


### PR DESCRIPTION
Ports over some base race changes from old mithra. I haven't actually played back when these changes were in use previously, but ive tested most of the big changes. Heres the new features as far as I can tell:

Teshari: Removed additional heavy item slowdown and raised base HP by 25 (50 > 75), but they are very short sighted (think constantly wearing a welding mask)

Vassel... Spider people: Regained their weave web tile ability. Takes 500 nutrition to make a single tile (you need to be very overfed). Also are immune to getting stuck in spider webs.

Tajaran: They now take toxin damage and are made Jittery by drinking caffine

Sergal: some darksight, a little faster base move speed, small weakness to fire, faster metabolism, and adjustments to their comfortable temperature thresholds (comfortable in colder temps i believe?)

Akula: Sharp bite replaced by strong bite, some darksight, faster in water, but much more vulnerable to shocks. Also does some stuff with their assisted languages?

Both zorren: small changes to their assisted languages

Vulpkanin: Temperature threshold changes.

Unathi: Removed their slower bleeding rate.